### PR TITLE
Add support for forcing input to upper or lower case

### DIFF
--- a/jquery.alphanum.js
+++ b/jquery.alphanum.js
@@ -55,7 +55,9 @@
 		allowSpace         : true, // Allow the space character
 		allowNumeric       : true, // Allow digits 0-9
 		allowUpper         : true, // Allow upper case characters
+		forceUpper         : false,// Convert lower case characters to upper case
 		allowLower         : true, // Allow lower case characters
+		forceLower         : false,// Convert upper case characters to lower case
 		allowCaseless      : true, // Allow characters that don't have both upper & lower variants - eg Arabic or Chinese
 		allowLatin         : true, // a-z A-Z
 		allowOtherCharSets : true, // eg é, Á, Arabic, Chinese etc
@@ -192,7 +194,7 @@
 				// Unfortunately, it isn't enough to just check if the new char is valid because some chars
 				// are position sensitive eg the decimal point '.'' or the minus sign '-'' are only valid in certain positions.
 				var potentialTextAfterKeypress = textBeforeKeypress.substring(0, start) + newChar + textBeforeKeypress.substring(end);
-				var validatedText              = trimFunction(potentialTextAfterKeypress, settings);
+				var validatedText              = trimFunction(potentialTextAfterKeypress, settings, true);
 
 				// If the keypress would cause the textbox to contain invalid characters, then cancel the keypress event
 				if(validatedText != potentialTextAfterKeypress)
@@ -472,7 +474,7 @@
 	/********************************
 	 * Trims a string according to the settings provided
 	 ********************************/
-	function trimAlphaNum(inputString, settings){
+	function trimAlphaNum(inputString, settings, noForceCase){
 		
 		if(typeof inputString != "string")
 			return inputString;
@@ -488,8 +490,19 @@
 			if(alphanum_allowChar(validatedStringFragment, Char, settings))
 				outChars.push(Char);
 		}
+
+		var outputString = outChars.join("");
+
+		if(!noForceCase) {
+			if(settings.forceLower) {
+				outputString = outputString.toLowerCase();
+			}
+			else if(settings.forceUpper) {
+				outputString = outputString.toUpperCase();
+			}
+		}
 		
-		return outChars.join("");
+		return outputString;
 	}
 	
 	function trimNum(inputString, settings){


### PR DESCRIPTION
This patch adds two new settings: `forceUpper` and `forceLower`. This enables input to be converted to upper or lower case, instead of preventing users from entering upper case or lower case letters as with the existing `allowUpper` and `allowLower` settings.

For example, we want all usernames to be entered in lower case:

``` javascript
$('#username').alphanum({
    allowSpace: false,
    allowUpper: true,
    allowLower: true,
    forceLower: true
});
```

Now, if a user types a capital **A** it will be changed to a small **a**, instead of being silently discarded.
