### PR TITLE
Workaround #19

### DIFF
--- a/jquery.alphanum.js
+++ b/jquery.alphanum.js
@@ -182,7 +182,14 @@
 				var newChar         = String.fromCharCode(charCode);
 
 				// Determine if some text was selected / highlighted when the key was pressed
-				var selectionObject = $textbox.selection();
+				var selectionObject;
+				try {
+					selectionObject = $textbox.selection();
+				} catch (e) {
+					// This can happen on browsers that removed selection API from some
+					// elements. See https://github.com/KevinSheedy/jquery.alphanum/issues/19
+					selectionObject = {start: 0, end: $textbox.val().length};
+				}
 				var start = selectionObject.start;
 				var end   = selectionObject.end;
 


### PR DESCRIPTION
Don't die if `.selection()` fails due to #19.